### PR TITLE
Add RF protocol support

### DIFF
--- a/mochad-device-schema.coffee
+++ b/mochad-device-schema.coffee
@@ -1,6 +1,6 @@
 module.exports = {
   title: "pimatic-mochad device config schemas"
-  Mochad: 
+  Mochad:
     title: "Mochad config options"
     type: "object"
     properties:
@@ -29,9 +29,9 @@ module.exports = {
         description: "Units that this mochad handles"
         type: "array"
         default: []
-        items: 
-          type: "object",  
-          properties: 
+        items:
+          type: "object",
+          properties:
             id:
               description: "Unique id"
               type: "string"
@@ -45,7 +45,7 @@ module.exports = {
               description: "Unique name"
               type: "string"
               required: true
-            housecode:   
+            housecode:
               description: "X10 housecode"
               type: "string"
               required: true
@@ -56,4 +56,9 @@ module.exports = {
               required: true
               minimum: 1
               maximum: 16
+            protocol:
+              description: "X10 protocol (RF/PL)"
+              type: "string"
+              default: "pl"
+              enum: ["rf", "pl"]
 }


### PR DESCRIPTION
This resolves petski/pimatic-mochad#3 by adding protocol support. It adds a new field to the device unit schema called protocol, this defaults to "pl", but can also be "rf". 

I also fixed what appear to be a bug that prevented me from ever toggling lights on or off once, the regex wasn't matching for me, so I modified to match so that the device's state got updated properly. I didn't take the time to fully understand what the purpose of `lastSeen` is, but this made it work well for me.
